### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VBOX = "ubuntu/precise64"
+VBOX = "ubuntu/trusty64"
 
 VAGRANTFILE_API_VERSION = "2"
 


### PR DESCRIPTION
Ubuntu 12.04 is no longer supported by the SIFT bootstrap script. Changing it the box to Ubuntu 14.04 solves the error "SIFT is only installable on Ubuntu 14.04 at this time" that happens on `vagrant up`.
